### PR TITLE
Move to a folder location for uploads and handle AWS auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ RUN pip3 install awscli --upgrade
 
 COPY entrypoint.sh .
 COPY backup.sh .
-COPY upload.sh .
+COPY upload-destinations upload-destinations
 
 RUN chmod +x entrypoint.sh
 RUN chmod +x backup.sh
-RUN chmod +x upload.sh
+RUN chmod -R +x upload-destinations
 
 RUN mkdir /backups
 RUN chgrp -R 0 /backups && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,8 @@
 
 set -eu
 
+# This runs the backup using the built in OC cluster backup
 ./backup.sh
-./upload.sh
+
+# Run the uploads for various destinations
+./upload-destinations/aws-s3.sh

--- a/upload-destinations/aws-s3.sh
+++ b/upload-destinations/aws-s3.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+echo "Sending backups to S3..."
+
+if [ ! -z "$S3_BUCKET" &&  ! -z "$AWS_SECRET_ACCESS_KEY" &&  ! -z "$AWS_ACCESS_KEY_ID" &&  ! -z "$AWS_DEFAULT_REGION" ]; then
+  aws s3 sync /backup s3://$S3_BUCKET/etcd --region=${AWS_DEFAULT_REGION} --expires "$(date -d '+7 days' --utc +'%Y-%m-%dT%H:%M:%SZ')"
+fi

--- a/upload.sh
+++ b/upload.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-echo "Sending backups to S3..."
-
-aws s3 sync /backup s3://$S3_BUCKET/etcd --region=${AWS_DEFAULT_REGION} --expires "$(date -d '+7 days' --utc +'%Y-%m-%dT%H:%M:%SZ')"


### PR DESCRIPTION
- Moves the upload scripts into their own folders - closes #2 
- Only runs the AWS upload if the environment variables are supplied - closes #1 